### PR TITLE
Set visibility to fix freeze bug on android 7

### DIFF
--- a/Source/ZXing.Net.Mobile.Android/ZXingSurfaceView.cs
+++ b/Source/ZXing.Net.Mobile.Android/ZXingSurfaceView.cs
@@ -100,6 +100,9 @@ namespace ZXing.Mobile
 
         public void StartScanning(Action<Result> scanResultCallback, MobileBarcodeScanningOptions options = null)
         {
+            //fix Android 7 bug: camera freezes because surfacedestroyed function isn't always called correct, the old surfaceview was still visible.
+            this.Visibility = ViewStates.Visible;
+
             //make sure the camera is setup
             _cameraAnalyzer.SetupCamera();
 
@@ -115,6 +118,8 @@ namespace ZXing.Mobile
         public void StopScanning()
         {
             _cameraAnalyzer.ShutdownCamera();
+            //fix Android 7 bug: camera freezes because surfacedestroyed function isn't always called correct, the old surfaceview was still visible.
+            this.Visibility = ViewStates.Gone;
         }
 
         public void PauseAnalysis()


### PR DESCRIPTION
Fixed an Android 7 bug. If you shutdown the camera the surfaceview isn't destroyed always correct, it was still visible. 